### PR TITLE
[240611] DP 2문제

### DIFF
--- a/0x10/BOJ_15486_answer.cpp
+++ b/0x10/BOJ_15486_answer.cpp
@@ -1,0 +1,51 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+/*
+  BOJ 15486 골드5 "퇴사 2"
+  https://www.acmicpc.net/problem/15486
+
+  1. 테이블 정의
+    dp[k] = k일부터 시작했을 때 최대 수익
+  2. 점화식 정의
+    2-1. i일에 상담한 경우 날짜가 n일을 넘지 않는다면?
+        dp[i] = max( dp[i+t[i]] + p[i], dp[i+1])
+        {(i+t[i])일의 수익과 현재 날짜의 수익} vs {i+1일 시작했을 때의 수익} 의 최대값
+        이를 n부터 1일까지 순회하기 때문에, dp[i+1]은 항상 최대 수익을 유지하고 있음 
+        따라서 현재 날짜에 상담한 경우의 수익과, 그러지 않는 경우의 최대 수익을 비교해야 함!
+
+    2-2. n일을 넘는다면?
+        현재 날짜의 상담을 못하니 최대 수익으로 갱신함
+
+  3. 초기값
+    dp[0] = 0, dp[n+1] = 0;
+*/
+int n;
+int ans;
+vector<int> t;
+vector<int> p;
+vector<int> dp;
+int main(){
+  t.push_back(0); // index 0
+  p.push_back(0); // index 0
+  int num1;
+  int num2;
+  cin >> n;
+  dp.assign(n+2, 0); // is it right?
+  for(int i = 0; i<n; i++){
+    cin >> num1 >> num2;
+    t.push_back(num1);
+    p.push_back(num2);
+  }
+  for(int i = n; i>=1; i--){
+    if(i+t[i] <= n+1){
+      dp[i] = max(dp[i+t[i]] + p[i], dp[i+1]);
+    }
+    else{
+      dp[i] = dp[i+1];
+    }
+  }
+  cout << *max_element(dp.begin(), dp.end());
+}

--- a/0x10/BOJ_9251_answer.cpp
+++ b/0x10/BOJ_9251_answer.cpp
@@ -1,0 +1,36 @@
+#include <iostream>
+#include <string>
+#include <algorithm>
+using namespace std;
+/*
+    BOJ 9251 골드5 "LCS"
+    https://www.acmicpc.net/problem/9251
+
+    1. 테이블 정의
+        dp[i][j] = str1의 0~i-1까지의 부분 문자열과 str2의 0~j-1까지의 부분 문자열 간의 LCS 
+    2. 점화식 정의
+        dp[i][j] 는
+        if(str1[i-1] == str2[j-1]) // 현재 두 문자가 같다면 이전 문자열[i-1][j-1]의 길이에 현재 문자 길이(1)를 더하면 됨
+            dp[i-1][j-1] + 1
+        else                       // i가 없을 경우의 길이와 j가 없을 경우의 길이의 최대값
+            max(dp[i-1][j], dp[i][j-1])
+    3. 초기값
+        dp의 0행, 0열은 모두 0으로 초기화
+*/
+string str1;
+string str2;
+int dp[1001][1001];
+int main(){
+  cin >> str1 >> str2;
+  for(int i = 1; i<=str1.length(); i++){
+    for(int j = 1; j<= str2.length(); j++){
+      if(str1[i-1] == str2[j-1]){
+        dp[i][j] = dp[i-1][j-1] + 1;
+      }
+      else{
+        dp[i][j] = max(dp[i-1][j], dp[i][j-1]);
+      }
+    }
+  }
+  cout << dp[str1.length()][str2.length()];
+}


### PR DESCRIPTION
## [퇴사 2](https://www.acmicpc.net/problem/15486)
[퇴사](https://www.acmicpc.net/problem/14501) (#56) 문제의 이중 for문을 쓰지 않고 푸는 방법으로 풀면 되는 문제였음... 다만 그것이 내가 푼 방식이 아니라 떠오르지 않았음 ㅠㅠ

이중 for문 방식은 테이블 정의 시, `dp[k]` 를 **k번째 일까지 최대 이익**으로 정의했기에, 계속 **0부터 다시 순회해야 하는 문제**가 있었음

하지만 `dp[k]`를 **k번째 일부터 시작할 경우, 최대 이익**으로 정의하면 for문 하나로 정답을 구할 수 있음. 다만 `n`부터 `1`까지 순회해야 하는 것이 특징임. 
`1`부터 순회한다면 당연히 `dp[k]`값은 `p[k]`와 같을 것이기 때문,  또한 `k`번째 일부터 **시작**하는 것이기 때문에 `dp[k]`를 구할 때 `dp[k+1]` 값을 이용할 수 있음

따라서 점화식은
```C++
if( i + t[i] <= n+1 )
 dp[i] = max(dp[ i + t[i]] + p[i], dp[i+1])  // i번째 일에 상담을 하는 경우와 하지 않는 경우의 최대값
else
 dp[i] = dp[i+1]; // i번째 일에 상담을 못하니까, 현재 최대값인 dp[i+1]로 저장
```


## [LCS](https://www.acmicpc.net/problem/9251)
풀기 시작한 지 10분만에, 이건 내가 못푸는 문제다! 포기! 해버림 ㅋㅋ
두 문자열을 비교해야 하기 때문에, dp 테이블을 2차원으로 만들 수 있었을 텐데 거기까지 생각도 못했다.
결국 구글링... [참고](https://velog.io/@emplam27/%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-%EA%B7%B8%EB%A6%BC%EC%9C%BC%EB%A1%9C-%EC%95%8C%EC%95%84%EB%B3%B4%EB%8A%94-LCS-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98-Longest-Common-Substring%EC%99%80-Longest-Common-Subsequence#longest-common-subsequence-substring)

`dp[i][j]`는 **`str1`의 `i-1`번째까지의 부분 문자열과 `str2`의 `j-1`번째 까지의 부분 문자열 간 LCS 길이**이다.
일단 dp 배열의 0행과 0열은 모두 0으로 초기화하여, index는 모두 1부터 시작하는 것으로 한다. (그렇기 때문에 위 테이블 정의에서 `str1`의 `i-1`인 것임)

   **0 A C A Y K P**
**0** 0 0 0 0 0 0 0 
**C** 0
**A** 0
**P** 0
**C** 0
**A** 0
**K** 0

만약 두 문자열 i, j번째의 문자가 같다면 이전 부분 문자열인 `dp[i-1][j-1]`길이의 1만 더해주면 된다. 
두 문자가 다르다면, 두 문자 중 하나가 없을 경우(총 2가지) 중 최대 길이로 저장한다.
ex) "ACA"와 "CAPC" 문자열 비교 시, 각 문자열의 마지막 문자 "A"와 "C"가 다르다. 이때 str1의 "A"가 없는 경우: "AC"와 "CAPC"의 LCS는 2("AC"), `str2`의 "C"가 없는 경우: "ACA"와 "CAP"의 LCS는 2("CA") 
위 두가지의 최대값인 2로 저장되어야 한다. **사실 이건 머리속에 팍 하고 꽂히진 않는다ㅠㅠ** 